### PR TITLE
Add video feature to landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ hugo.linux
 
 # Temporary lock file while building
 /.hugo_build.lock
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ hugo.linux
 
 # Temporary lock file while building
 /.hugo_build.lock
-.venv/
+

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -46,6 +46,7 @@ params:
     enabled: true
     title: Taranis AI
     imageUrl: "/screenshot.png"
+    videoUrl: "/taranis-walkthrough-video.webm"
     imageTitle: "Screenshot of Taranis AI"
     subtitle: |
       **Taranis AI** is an advanced Open-Source Intelligence (OSINT) tool, leveraging Artificial Intelligence to revolutionize information gathering and situational analysis.

--- a/themes/taranis/layouts/partials/index_profile.html
+++ b/themes/taranis/layouts/partials/index_profile.html
@@ -3,9 +3,8 @@
     <div class="profile_inner">
         <h1>{{ .title | default site.Title | markdownify }}</h1>
         <span>{{ .subtitle | markdownify }}</span>
-        {{- if .videoUrl -}}
         <style>
-            .video-container {
+            .media-container {
                 position: relative;
                 padding-bottom: 56.25%; /* 16:9 aspect ratio */
                 height: 0;
@@ -14,7 +13,7 @@
                 margin-top: 10px;
             }
 
-            .video-container video {
+            .media-container video {
                 position: absolute;
                 top: 0;
                 left: 0;
@@ -22,12 +21,15 @@
                 height: 100%;
             }
         </style>
-        <div class="video-container">
-            <video controls poster="{{ .imageUrl | absURL }}">
+        {{- if .videoUrl }}
+        <div class="media-container">
+            <video controls {{ if .imageUrl }}poster="{{ .imageUrl | absURL }}"{{ end }}>
                 <source src="{{ .videoUrl }}" type="video/webm">
                 Your browser does not support the video tag.
             </video>
         </div>
+        {{- else if .imageUrl }}
+        <img draggable="false" src="{{ .imageUrl | absURL }}" alt="{{ .imageTitle | default "profile image" }}" title="{{ .imageTitle }}" class="profile-banner" style="width: 100%; height: auto; object-fit: cover;"/>
         {{- end }}
 
         {{- if .description -}}

--- a/themes/taranis/layouts/partials/index_profile.html
+++ b/themes/taranis/layouts/partials/index_profile.html
@@ -3,8 +3,31 @@
     <div class="profile_inner">
         <h1>{{ .title | default site.Title | markdownify }}</h1>
         <span>{{ .subtitle | markdownify }}</span>
-        {{- if .imageUrl -}}
-        <img draggable="false" src="{{ .imageUrl | absURL }}" alt="{{ .imageTitle | default "profile image" }}" title="{{ .imageTitle }}" class="profile-banner"/>
+        {{- if .videoUrl -}}
+        <style>
+            .video-container {
+                position: relative;
+                padding-bottom: 56.25%; /* 16:9 aspect ratio */
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                margin-top: 10px;
+            }
+
+            .video-container video {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+        <div class="video-container">
+            <video controls poster="{{ .imageUrl | absURL }}">
+                <source src="{{ .videoUrl }}" type="video/webm">
+                Your browser does not support the video tag.
+            </video>
+        </div>
         {{- end }}
 
         {{- if .description -}}
@@ -19,7 +42,7 @@
         <div class="buttons">
             {{- range . }}
             <a class="button" href="{{ trim .url " " }}" rel="noopener" title="{{ .name }}">
-                <span class="button-inner">
+            <span class="button-inner">
                 {{ .name }}
                 </span>
             </a>


### PR DESCRIPTION
This pull request adds a video feature tot the landing page

**Code Changes:**
- Implemented a `media-container` class to handle both video and image display in the `index.profile.html` file.
- Updated the CSS to make the video fit the container, in a 16:9 aspect ratio.
- Added logic to automatically show a video with a thumbnail image when both are available, show only the video when an image isn't provided, and show only the image when a video isn't available.

- Included a `video` tag with controls and a thumbnail image to show before the video plays. The video container has a `max-width` of 100%, so it can resize across different screen sizes. Added `margin-top` for improved spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Added video playback functionality to user profiles. Images are replaced with a video player if `videoUrl` is provided.
- **Chores**
    - Updated `.gitignore` to exclude the virtual environment directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->