### PR TITLE
Documentation: Explain SimpleWebCollector JavaScript support

### DIFF
--- a/content/en/docs/admin/collectors.md
+++ b/content/en/docs/admin/collectors.md
@@ -70,4 +70,4 @@ Digest Splitting is a feature that allows the user to split all available URLs i
 The Digest Splitting Limit is the maximum number of URLs that will be split into individual News Items. If the limit is reached, the remaining URLs are dropped.
 The Digest Splitting Limit is set to 30 by default but can be adjusted by the administrator. It is generally recommended to keep the limit low to avoid overloading the system, which could lead to unsuccessful gathering.
 
-_Note: Digest splitting can fail if the web page contains JavaScript. As of now, there is no workaround but it might be improved in the future releases._
+[Simple Web Collector](#simple-web-collector) will fail if the web page content is only available with JavaScript. Switching to the Selenium based "Web Collector" will allow parsing JavaScript based websites, but as of right now "Web Collector" does not support Digest Splitting.

--- a/content/en/docs/admin/collectors.md
+++ b/content/en/docs/admin/collectors.md
@@ -18,11 +18,15 @@ RSS Collector enables Taranis AI to collect data from a user-defined RSS feed (S
   * **FEED_URL**
 * Optional fields:
   * USER_AGENT
-  * CONTENT_LOCATION
   * PROXY_SERVER
+  * ADDITIONAL_HEADERS [accepts a valid `json`] (can be used to add additional headers, not all headers work as expected)
+  * CONTENT_LOCATION
+  * XPATH
+  * TLP_LEVEL
   * REFRESH_INTERVAL (see [Bots - refresh_interval](/docs/admin/bots/#bot's-settings))
-  * Digest Splitting On/Off
+  * DIGEST_SPLITTING On/Off (creates News Items out of URLs present in the `Summary` field of RSS feed)
   * DIGEST_SPLITTING_LIMIT (default: 30)
+  * BROWSER_MODE On/Off (see [Browser Mode](#browser-mode))
 
 ### Basic configuration
 * Example: 
@@ -33,6 +37,11 @@ The RSS Collector supports the use of XPath for locating elements. (See Simple W
 * Example:
   * **FEED_URL**: https://www.bsi.bund.de/SiteGlobals/Functions/RSSFeed/RSSNewsfeed/RSSNewsfeed.xml
   * **XPATH**: //*[@id="getting-started-web-console-creating-new-project_openshift-web-console"]
+  * **ADDITIONAL_HEADERS**: `{
+    "AUTHORIZATION": "Bearer Token1234",
+    "X-API-KEY": "12345",
+    "Cookie": "firstcookie=1234; second-cookie=4321",
+}`
 
 
 ## Simple Web Collector
@@ -42,7 +51,12 @@ Simple Web Collector enables Taranis AI to collect data using web URLs and XPath
 * Optional fields:
   * USER_AGENT
   * PROXY_SERVER
+  * ADDITIONAL_HEADERS
   * XPATH
+  * TLP_LEVEL
+  * DIGEST_SPLITTING On/Off
+  * DIGEST_SPLITTING_LIMIT (default: 30)
+  * BROWSER_MODE On/Off (see [Browser Mode](#browser-mode))
 
 ### Basic configuration
 The simplest way to use this collector is to use the **WEB_URL** field only. 
@@ -56,18 +70,20 @@ It is crucial to specify the XPath of the precise element containing the desired
 
 
 ## RT Collector
-RT Collector enables Taranis AI to collect data from a user-defined RT instance.
+RT Collector enables Taranis AI to collect data from a user-defined [Request Tracker](https://bestpractical.com/request-tracker) instance.
 
 * Required fields:
   * **BASE_URL**: Base URL of the RT instance (e.g. `localhost`).
   * **RT_TOKEN**: User token for the RT instance.
 
 * Optional fields:
-  * **TLP_LEVEL**
+  * ADDITIONAL_HEADERS
+  * TLP_LEVEL
 
 ## Digest Splitting
 Digest Splitting is a feature that allows the user to split all available URLs in the located element into individual News Items.
 The Digest Splitting Limit is the maximum number of URLs that will be split into individual News Items. If the limit is reached, the remaining URLs are dropped.
-The Digest Splitting Limit is set to 30 by default but can be adjusted by the administrator. It is generally recommended to keep the limit low to avoid overloading the system, which could lead to unsuccessful gathering.
+The Digest Splitting Limit is set to 30 News Items by default but can be adjusted by the administrator. Useful in case of timeouts during collection of too many News Items.
 
-[Simple Web Collector](#simple-web-collector) will fail if the web page content is only available with JavaScript. Switching to the Selenium based "Web Collector" will allow parsing JavaScript based websites, but as of right now "Web Collector" does not support Digest Splitting.
+## Browser Mode
+Collectors will fail if the web page content is only available with JavaScript. In that case it is possible to turn on the **Browser Mode**. All requests will have JavaScript enabled, therefore, it is slower and can use more resources.

--- a/content/en/docs/admin/collectors.md
+++ b/content/en/docs/admin/collectors.md
@@ -34,11 +34,6 @@ The RSS Collector supports the use of XPath for locating elements. (See Simple W
   * **FEED_URL**: https://www.bsi.bund.de/SiteGlobals/Functions/RSSFeed/RSSNewsfeed/RSSNewsfeed.xml
   * **XPATH**: //*[@id="getting-started-web-console-creating-new-project_openshift-web-console"]
 
-### Digest Splitting
-Digest Splitting is a feature that allows the user to split all available URLs in the RSS feed into individual News Items.
-The Digest Splitting Limit is the maximum number of URLs that will be split into individual News Items. If the limit is reached, the remaining URLs are dropped.
-The Digest Splitting Limit is set to 30 by default but can be adjusted by the administrator. It is generally recommended to keep the limit low to avoid overloading the system, which could lead to unsuccessful gathering.
-
 
 ## Simple Web Collector
 Simple Web Collector enables Taranis AI to collect data using web URLs and XPaths.
@@ -69,3 +64,10 @@ RT Collector enables Taranis AI to collect data from a user-defined RT instance.
 
 * Optional fields:
   * **TLP_LEVEL**
+
+## Digest Splitting
+Digest Splitting is a feature that allows the user to split all available URLs in the located element into individual News Items.
+The Digest Splitting Limit is the maximum number of URLs that will be split into individual News Items. If the limit is reached, the remaining URLs are dropped.
+The Digest Splitting Limit is set to 30 by default but can be adjusted by the administrator. It is generally recommended to keep the limit low to avoid overloading the system, which could lead to unsuccessful gathering.
+
+_Note: Digest splitting can fail if the web page contains JavaScript. As of now, there is no workaround but it might be improved in the future releases._


### PR DESCRIPTION
Simple Web Collector will fail if the web page content is only available with JavaScript. Switching to the Selenium based "Web Collector" will allow parsing JavaScript based websites, but as of right now "Web Collector" does not support Digest Splitting.

Documentation should also include a reference to the used technologies of the corresponding Collectors and their limitations.

SimpleWebCollector: python requests
WebCollector: Selenium
