### PR TITLE
Document release-aligned operations guidance

### DIFF
--- a/content/en/docs/admin/bots.md
+++ b/content/en/docs/admin/bots.md
@@ -20,6 +20,7 @@ Bots run as worker jobs. They can be triggered manually, scheduled with `REFRESH
 | Summary Bot | Generates Story summaries and, optionally, Story titles. |
 | Sentiment Analysis Bot | Adds sentiment attributes to News Items. |
 | Cybersecurity Classifier Bot | Classifies whether Story content is cybersecurity related. |
+| IntelOwl Bot | Enriches IOC tags through an IntelOwl instance. |
 
 Implementation details are available in the [worker bot source](https://github.com/taranis-ai/taranis-ai/tree/master/src/worker/worker/bots).
 
@@ -32,11 +33,14 @@ Implementation details are available in the [worker bot source](https://github.c
 | Type | Bot implementation to run. |
 | Index | Execution order when multiple bots run after collection. |
 | `RUN_AFTER_COLLECTOR` | Runs the bot after collector jobs. |
+| `RUN_AFTER_BOTS` | Optional configured bot instances that must finish before this bot runs. |
 | `REFRESH_INTERVAL` | Cron-like schedule, for example `0 */8 * * *`. |
 | `REQUESTS_TIMEOUT` | HTTP timeout for calls to external bot services. |
 | `BOT_API_KEY` | API key sent to external bot services when needed. |
 
 Scheduled bots are handled by Redis/RQ. See [Background Jobs](/docs/getting-started/07_background-jobs/) for worker and scheduler health checks.
+
+Use the bot run-order editor instead of entering `RUN_AFTER_BOTS` manually. Bot dependencies refer to configured bot instances, not bot types. The IntelOwl Bot depends on the IOC Bot so it can enrich extracted indicators.
 
 ## LLM-backed bots
 
@@ -62,3 +66,7 @@ The Sentiment Analysis Bot writes these News Item attributes:
 - `sentiment_category`
 
 The Story Edit advanced view displays the sentiment status when these attributes are present.
+
+## IntelOwl enrichment
+
+The [IntelOwl enrichment guide](/docs/admin/intelowl/) covers required analyzers, bot configuration, and viewing CTI results.

--- a/content/en/docs/admin/intelowl.md
+++ b/content/en/docs/admin/intelowl.md
@@ -10,7 +10,7 @@ Taranis AI can send indicators of compromise (IOCs) to an IntelOwl instance thro
 
 1. Deploy IntelOwl using its supported installation method and wait for its first-run migrations to finish.
 2. Create a dedicated IntelOwl API token for Taranis AI.
-3. Enable and configure at least one requested analyzer for every IOC type you intend to enrich.
+3. Enable and configure at least one supported analyzer for every IOC type you intend to enrich.
 4. In Taranis AI, enable **IOC Bot** and **IntelOwl Bot**. Keep IOC Bot before IntelOwl Bot in the bot run order.
 
 Configure the IntelOwl Bot with:
@@ -23,11 +23,11 @@ Configure the IntelOwl Bot with:
 | `INTEL_OWL_TLP` | TLP shared with IntelOwl; normally `CLEAR`. |
 | `INTEL_OWL_POLL_TIMEOUT_SECONDS` | Maximum wait for IntelOwl processing; defaults to 1800 seconds. |
 
-## Required analyzers
+## Supported analyzers
 
-Taranis AI requests a fixed analyzer set based on the IOC type. IntelOwl must have at least one usable analyzer for each type you want to process.
+Taranis AI supports the following IntelOwl analyzers for each IOC type. Configure at least one listed analyzer for each type you want to process.
 
-| IOC type | Requested analyzers |
+| IOC type | Supported analyzers |
 | --- | --- |
 | CVE | `NVD_CVE`, `Vulners` |
 | IP | `ThreatFox`, `URLhaus`, `AbuseIPDB`, `GreyNoiseCommunity`, `VirusTotal_v3_Get_Observable` |
@@ -36,7 +36,7 @@ Taranis AI requests a fixed analyzer set based on the IOC type. IntelOwl must ha
 | Hash | `MalwareBazaar_Get_Observable`, `YARAify_Search`, `VirusTotal_v3_Get_Observable` |
 | Email | `EmailRep`, `HaveIBeenPwned` |
 
-If IntelOwl reports that no analyzers can run, enable the requested analyzer in IntelOwl and configure its required provider credentials. Check IntelOwl's job detail for the missing analyzer or credential.
+If IntelOwl reports that no analyzer can run, enable a listed analyzer and configure its required provider credentials. Check the job detail for the missing analyzer or credential.
 
 ## View enrichment results
 

--- a/content/en/docs/admin/intelowl.md
+++ b/content/en/docs/admin/intelowl.md
@@ -1,0 +1,49 @@
+---
+title: "IntelOwl Enrichment"
+description: "Configure IntelOwl enrichment for indicators of compromise."
+weight: 7
+---
+
+Taranis AI can send indicators of compromise (IOCs) to an IntelOwl instance through the disabled-by-default **IntelOwl Bot**. IntelOwl configuration errors, such as disabled or unconfigured analyzers, are reported by IntelOwl and are not worker-connectivity failures.
+
+## Prerequisites
+
+1. Deploy IntelOwl using its supported installation method and wait for its first-run migrations to finish.
+2. Create a dedicated IntelOwl API token for Taranis AI.
+3. Enable and configure at least one requested analyzer for every IOC type you intend to enrich.
+4. In Taranis AI, enable **IOC Bot** and **IntelOwl Bot**. Keep IOC Bot before IntelOwl Bot in the bot run order.
+
+Configure the IntelOwl Bot with:
+
+| Setting | Purpose |
+| --- | --- |
+| `INTEL_OWL_URL` | IntelOwl URL reachable from the worker container or pod. |
+| `INTEL_OWL_API_KEY` | Dedicated IntelOwl API token. |
+| `INTEL_OWL_TLS_VERIFY` | Keep enabled except for a local self-signed test instance. |
+| `INTEL_OWL_TLP` | TLP shared with IntelOwl; normally `CLEAR`. |
+| `INTEL_OWL_POLL_TIMEOUT_SECONDS` | Maximum wait for IntelOwl processing; defaults to 1800 seconds. |
+
+## Required analyzers
+
+Taranis AI requests a fixed analyzer set based on the IOC type. IntelOwl must have at least one usable analyzer for each type you want to process.
+
+| IOC type | Requested analyzers |
+| --- | --- |
+| CVE | `NVD_CVE`, `Vulners` |
+| IP | `ThreatFox`, `URLhaus`, `AbuseIPDB`, `GreyNoiseCommunity`, `VirusTotal_v3_Get_Observable` |
+| Domain | `URLhaus`, `ThreatFox`, `OTXQuery`, `VirusTotal_v3_Get_Observable` |
+| URL | `URLhaus`, `UrlScan_Search`, `VirusTotal_v3_Get_Observable` |
+| Hash | `MalwareBazaar_Get_Observable`, `YARAify_Search`, `VirusTotal_v3_Get_Observable` |
+| Email | `EmailRep`, `HaveIBeenPwned` |
+
+If IntelOwl reports that no analyzers can run, enable the requested analyzer in IntelOwl and configure its required provider credentials. Check IntelOwl's job detail for the missing analyzer or credential.
+
+## View enrichment results
+
+CTI dialogs show stored enrichment rows for matching IOCs on News Items, Stories, Reports, and Assets. Results remain subject to the user's normal permissions and TLP visibility.
+
+## Security
+
+Use a dedicated token and store it in protected configuration. Do not put IntelOwl or provider credentials in logs, screenshots, commits, or shared configuration files. Use HTTPS with TLS verification outside local development, and enable email analyzers only when the IntelOwl instance is approved to receive email-address IOCs.
+
+See the [IntelOwl installation documentation](https://intelowlproject.github.io/docs/IntelOwl/installation/) and [plugin configuration documentation](https://intelowlproject.github.io/docs/IntelOwl/usage/) for IntelOwl-specific setup.

--- a/content/en/docs/admin/intelowl.md
+++ b/content/en/docs/admin/intelowl.md
@@ -40,7 +40,7 @@ If IntelOwl reports that no analyzer can run, enable a listed analyzer and confi
 
 ## View enrichment results
 
-CTI dialogs show stored enrichment rows for matching IOCs on News Items, Stories, Reports, and Assets. Results remain subject to the user's normal permissions and TLP visibility.
+You can view enrichment results for matching IOCs in the CTI dialogs for News Items, Stories, Reports, and Assets. Your normal permissions and TLP visibility still apply.
 
 ## Security
 

--- a/content/en/docs/admin/osint-workflow.md
+++ b/content/en/docs/admin/osint-workflow.md
@@ -72,6 +72,8 @@ RUN_AFTER_COLLECTOR: Indicates if bot is active after collection
 
 LLM-backed bots can use the optional [LLM Bot Service](/docs/getting-started/08_llm-bot/). Full bot configuration is documented in [Bots](/docs/admin/bots/).
 
+The optional IntelOwl Bot enriches indicators extracted by the IOC Bot. Configure IntelOwl and keep the IOC Bot before it in the run order; see [IntelOwl enrichment](/docs/admin/intelowl/).
+
 ![bot_selection](/docs/osint/bot_selection.png)
 
 ## 6. Collect Sources

--- a/content/en/docs/admin/user-management.md
+++ b/content/en/docs/admin/user-management.md
@@ -13,6 +13,8 @@ Organizations can be added with following parameters defining them: name, descri
 
 Define roles with permissions. Roles are then assigned to users to control access to administration, Assess, Analyze, Publish, connector, and worker features.
 
+Access-control lists (ACLs) restrict user-facing content and reference data. A source can be granted directly or through an ACL on one of its source groups; a source-group wildcard grants access to all sources, including ungrouped sources. `ADMIN_OPERATIONS` bypasses these ACL checks, but does not bypass TLP restrictions. Administration and configuration access is controlled by the relevant `CONFIG_*` permissions.
+
 ### Users
 
 Manage users and assign them roles and an organization.

--- a/content/en/docs/admin/user-management.md
+++ b/content/en/docs/admin/user-management.md
@@ -13,7 +13,7 @@ Organizations can be added with following parameters defining them: name, descri
 
 Define roles with permissions. Roles are then assigned to users to control access to administration, Assess, Analyze, Publish, connector, and worker features.
 
-Access-control lists (ACLs) restrict user-facing content and reference data. A source can be granted directly or through an ACL on one of its source groups; a source-group wildcard grants access to all sources, including ungrouped sources. `ADMIN_OPERATIONS` bypasses these ACL checks, but does not bypass TLP restrictions. Administration and configuration access is controlled by the relevant `CONFIG_*` permissions.
+Access-control lists (ACLs) restrict user-facing content and reference data. A user can be granted access to a source directly or through an ACL on one of its source groups; a source-group wildcard grants access to all sources, including ungrouped sources. `ADMIN_OPERATIONS` bypasses these ACL checks, but does not bypass TLP restrictions. Administration and configuration access is controlled by the relevant `CONFIG_*` permissions.
 
 ### Users
 

--- a/content/en/docs/getting-started/05_releases-and-tags.md
+++ b/content/en/docs/getting-started/05_releases-and-tags.md
@@ -18,8 +18,14 @@ Core Taranis AI services follow a **stable and tested** release process:
 | Tag | Description | Use Case | Stability |
 |-----|-------------|----------|-----------|
 | `stable` | Latest manually tested and verified release | **Production deployments** | ✅ High |
-| `v1.2.3` (semver) | Specific version (semantic versioning) | **Pinned production deployments** | ✅ High |
+| `1.2.3` (semver) | Specific version (semantic versioning) | **Pinned production deployments** | ✅ High |
 | `latest` | Latest build from main branch | **Development/testing only** | ⚠️ May contain bugs |
+
+## Upgrade support
+
+Only upgrades to the immediately following Taranis AI release are tested and supported. For a larger version gap, upgrade one release at a time and verify the deployment after every step.
+
+Review the [GitHub release notes](https://github.com/taranis-ai/taranis-ai/releases) before each upgrade. Follow [Maintenance](/docs/getting-started/10_maintainance/) for the upgrade, verification, and rollback procedure.
 
 ### For Bots
 

--- a/content/en/docs/getting-started/07_background-jobs.md
+++ b/content/en/docs/getting-started/07_background-jobs.md
@@ -58,6 +58,12 @@ Example degraded response:
 
 When `workers` is `down`, check the `collector`, `workers`, and `cron` containers or deployments first, then inspect worker logs for bad `WORKER_TYPES`, invalid API keys, Redis authentication failures, or failed bot service calls.
 
+## Task failures
+
+The task and Failed Jobs views report terminal RQ failures: unhandled task exceptions, job timeouts, and killed workhorse processes. Failed Jobs includes RQ's exception detail when it is available.
+
+A queued job without a worker, a late schedule, or a blocked queue is an operational liveness problem, not a recorded task failure. Check `/api/health`, the worker containers, and Redis connectivity before treating it as a failed task.
+
 ## Scheduled jobs
 
 Collectors and bots use cron-like schedules. Core stores managed schedule definitions in Redis, and the `cron` service reconciles those definitions with enabled sources and bots. Changing a collector or bot schedule does not require restarting the workers.

--- a/content/en/docs/getting-started/10_maintainance.md
+++ b/content/en/docs/getting-started/10_maintainance.md
@@ -8,6 +8,8 @@ weight: 10
 
 Use published images for deployment upgrades. Do not build application images on production hosts unless you are intentionally testing a custom build.
 
+Only upgrades to the immediately following Taranis AI release are tested and supported. For a larger version gap, upgrade one release at a time and verify the deployment after every step.
+
 ```bash
 cd taranis-ai/docker
 docker compose pull

--- a/content/en/docs/getting-started/15_advanced-monitoring.md
+++ b/content/en/docs/getting-started/15_advanced-monitoring.md
@@ -32,6 +32,12 @@ If this warning appears:
 
 See [Background Jobs](/docs/getting-started/07_background-jobs/) for worker services, queues, scheduler behavior, and Redis/RQ upgrade notes.
 
+## Audit logging
+
+Core audit logging is enabled by default. It writes structured JSON events to stdout for human-authenticated write requests and login attempts. Events contain request metadata such as the timestamp, path, status, user, and client IP; they never include request bodies, credentials, tokens, or other secrets.
+
+Set `AUDIT_LOG_ENABLED=false` only when log collection is not appropriate for the deployment. Send the core container's stdout to your normal log collector for retention and search.
+
 ## How to enable Sentry in Taranis AI
 
 To enable Sentry, set the `SENTRY_DSN` variables in the `.env` file before start of the application. More details about environment variables can be found [here](https://github.com/taranis-ai/taranis-ai/blob/master/docker/README.md).


### PR DESCRIPTION
Fixes the documentation side of: https://github.com/taranis-ai/taranis-ai/issues/960

Updates the public documentation for release-aligned operations and unreleased operator features.

  - Corrects pinned image-tag syntax and documents one-release-step upgrade support.
  - Adds terminal RQ task-failure guidance and clarifies that queue/scheduler liveness issues are not recorded as failures.
  - Documents core audit logging and RBAC/ACL behaviour.
  - Adds an IntelOwl enrichment guide and links it from Bots and the OSINT workflow.